### PR TITLE
Add support for clog stream

### DIFF
--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -432,8 +432,9 @@ namespace termcolor
         {
             if (&stream == &std::cout)
                 return stdout;
-            else if (&stream == &std::cerr)
+            else if ((&stream == &std::cerr) || (&stream == &std::clog))
                 return stderr;
+                
             return nullptr;
         }
 


### PR DESCRIPTION
Former code fired segmentation fault if output stream was `std::clog`. `stdio` doesn't know about log stream, we assume it's an error stream instead.