### PR TITLE
Improvements for vsc++

### DIFF
--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -8,9 +8,16 @@
 //! :copyright: (c) 2013 by Igor Kalnitsky
 //! :license: BSD, see LICENSE for details
 //!
+#pragma once
 
 #ifndef TERMCOLOR_HPP_
 #define TERMCOLOR_HPP_
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4800) //about force cast to bool
+#pragma warning(disable: 4005) //about changing macro in minwindef.h(130) (wtf?)
+#endif
 
 // the following snippet of code detects the current OS and
 // defines the appropriate macro that is used to wrap some
@@ -45,17 +52,95 @@
 
 namespace termcolor
 {
-    // Forward declaration of the `__internal` namespace.
-    // All comments are below.
+    //! Since C++ hasn't a way to hide something in the header from
+    //! the outer access, I have to introduce this namespace which
+    //! is used for internal purpose and should't be access from
+    //! the user code.
     namespace __internal
     {
-        inline FILE* get_standard_stream(const std::ostream& stream);
-        inline bool is_atty(const std::ostream& stream);
+        //! Since C++ hasn't a true way to extract stream handler
+        //! from the a given `std::ostream` object, I have to write
+        //! this kind of hack.
+        inline
+        FILE* get_standard_stream(const std::ostream& stream)
+        {
+            if (&stream == &std::cout)
+                return stdout;
+            else if (&stream == &std::cerr)
+                return stderr;
+            return nullptr;
+        }
+
+
+        //! Test whether a given `std::ostream` object refers to
+        //! a terminal.
+        inline
+        bool is_atty(const std::ostream& stream)
+        {
+            FILE* std_stream = get_standard_stream(stream);
+
+        #if defined(OS_MACOS) || defined(OS_LINUX)
+            return ::isatty(fileno(std_stream));
+        #elif defined(OS_WINDOWS)
+            return ::_isatty(_fileno(std_stream));
+        #endif
+        }
+
 
     #if defined(OS_WINDOWS)
-        void win_change_attributes(std::ostream& stream, int foreground, int background=-1);
-    #endif
-    }
+        //! Change Windows Terminal colors attribute. If some
+        //! parameter is `-1` then attribute won't changed.
+        inline
+        void win_change_attributes(std::ostream& stream, int foreground, int background=-1)
+        {
+            // yeah, i know.. it's ugly, it's windows.
+            static WORD defaultAttributes = 0;
+
+            // get terminal handle
+            HANDLE hTerminal = INVALID_HANDLE_VALUE;
+            if (&stream == &std::cout)
+                hTerminal = GetStdHandle(STD_OUTPUT_HANDLE);
+            else if (&stream == &std::cerr)
+                hTerminal = GetStdHandle(STD_ERROR_HANDLE);
+
+            // save default terminal attributes if it unsaved
+            if (!defaultAttributes)
+            {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                    return;
+                defaultAttributes = info.wAttributes;
+            }
+
+            // restore all default settings
+            if (foreground == -1 && background == -1)
+            {
+                SetConsoleTextAttribute(hTerminal, defaultAttributes);
+                return;
+            }
+
+            // get current settings
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                return;
+
+            if (foreground != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0x0F);
+                info.wAttributes |= static_cast<WORD>(foreground);
+            }
+
+            if (background != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0xF0);
+                info.wAttributes |= static_cast<WORD>(background);
+            }
+
+            SetConsoleTextAttribute(hTerminal, info.wAttributes);
+        }
+    #endif // OS_WINDOWS
+
+    } // namespace __internal
 
 
     inline
@@ -416,103 +501,15 @@ namespace termcolor
         return stream;
     }
 
-
-
-    //! Since C++ hasn't a way to hide something in the header from
-    //! the outer access, I have to introduce this namespace which
-    //! is used for internal purpose and should't be access from
-    //! the user code.
-    namespace __internal
-    {
-        //! Since C++ hasn't a true way to extract stream handler
-        //! from the a given `std::ostream` object, I have to write
-        //! this kind of hack.
-        inline
-        FILE* get_standard_stream(const std::ostream& stream)
-        {
-            if (&stream == &std::cout)
-                return stdout;
-            else if ((&stream == &std::cerr) || (&stream == &std::clog))
-                return stderr;
-
-            return nullptr;
-        }
-
-
-        //! Test whether a given `std::ostream` object refers to
-        //! a terminal.
-        inline
-        bool is_atty(const std::ostream& stream)
-        {
-            FILE* std_stream = get_standard_stream(stream);
-
-        #if defined(OS_MACOS) || defined(OS_LINUX)
-            return ::isatty(fileno(std_stream));
-        #elif defined(OS_WINDOWS)
-            return ::_isatty(_fileno(std_stream));
-        #endif
-        }
-
-
-    #if defined(OS_WINDOWS)
-        //! Change Windows Terminal colors attribute. If some
-        //! parameter is `-1` then attribute won't changed.
-        void win_change_attributes(std::ostream& stream, int foreground, int background)
-        {
-            // yeah, i know.. it's ugly, it's windows.
-            static WORD defaultAttributes = 0;
-
-            // get terminal handle
-            HANDLE hTerminal = INVALID_HANDLE_VALUE;
-            if (&stream == &std::cout)
-                hTerminal = GetStdHandle(STD_OUTPUT_HANDLE);
-            else if (&stream == &std::cerr)
-                hTerminal = GetStdHandle(STD_ERROR_HANDLE);
-
-            // save default terminal attributes if it unsaved
-            if (!defaultAttributes)
-            {
-                CONSOLE_SCREEN_BUFFER_INFO info;
-                if (!GetConsoleScreenBufferInfo(hTerminal, &info))
-                    return;
-                defaultAttributes = info.wAttributes;
-            }
-
-            // restore all default settings
-            if (foreground == -1 && background == -1)
-            {
-                SetConsoleTextAttribute(hTerminal, defaultAttributes);
-                return;
-            }
-
-            // get current settings
-            CONSOLE_SCREEN_BUFFER_INFO info;
-            if (!GetConsoleScreenBufferInfo(hTerminal, &info))
-                return;
-
-            if (foreground != -1)
-            {
-                info.wAttributes &= ~(info.wAttributes & 0x0F);
-                info.wAttributes |= static_cast<WORD>(foreground);
-            }
-
-            if (background != -1)
-            {
-                info.wAttributes &= ~(info.wAttributes & 0xF0);
-                info.wAttributes |= static_cast<WORD>(background);
-            }
-
-            SetConsoleTextAttribute(hTerminal, info.wAttributes);
-        }
-    #endif // OS_WINDOWS
-
-    } // namespace __internal
-
 } // namespace termcolor
 
 
 #undef OS_WINDOWS
 #undef OS_MACOS
 #undef OS_LINUX
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // TERMCOLOR_HPP_


### PR DESCRIPTION
* #pragma once for faster preprocessing
* disabled warnings 4800 and 4005

And main improvements:
* replaced declaration of _internal's functions by its definitions
* made void win_change_attributes(...) inline

Now termcolor.hpp can be included multiple times without any conflicts (vs2015 requires only inline functions in .hpp files)